### PR TITLE
Added support for VTT subtitle file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ The following file types are supported.
 - _AVI_, _M4V_, _MKV_, _MOV_, _MP4_, _MPG_, _MPEG_, _OGG_, _OGM_, _WEBM_, _WMV_
 
 **Subtitle**:
-- _ASS_, _IDX_, _PGS_, _SMI_, _SRT_, _SSA_, _SUB_, _SUP_
+- _ASS_, _IDX_, _PGS_, _SMI_, _SRT_, _SSA_, _SUB_, _SUP_, _VTT_
 <br><br>
 
 ## 🙏 Attribution

--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
     "start:react": "react-scripts start",
     "test": "react-scripts test"
   },
-  "version": "2.4.0"
+  "version": "2.4.1"
 }

--- a/resources/modules/filewalker.py
+++ b/resources/modules/filewalker.py
@@ -89,7 +89,8 @@ class FileWalker:
       "srt",
       "ssa",
       "sub",
-      "sup"
+      "sup",
+      "vtt"
     ]
 
     """

--- a/scripts/package.js
+++ b/scripts/package.js
@@ -101,7 +101,7 @@ class Packager {
           banner: path('../utilities/msi/images/banner.png')
         }
       },
-      version: '2.4.0'
+      version: '2.4.1'
     });
 
     // Customized MSI template


### PR DESCRIPTION
This change adds support for [VTT](https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API) subtitle file types when merging. 